### PR TITLE
Fixed squidguard config location issue from T92 and T130

### DIFF
--- a/scripts/vyatta-update-webproxy.pl
+++ b/scripts/vyatta-update-webproxy.pl
@@ -48,7 +48,7 @@ my $squid_def_port  = 3128;
 my $squid_chain     = 'WEBPROXY_CONNTRACK';
 
 # squidGuard globals
-my $squidguard_conf          = '/etc/squid/squidGuard.conf';
+my $squidguard_conf          = '/etc/squidguard/squidGuard.conf';
 my $squidguard_redirect_def  = 'http://www.google.com';
 my $squidguard_enabled       = 0;
 


### PR DESCRIPTION
The location of the squidguard config file changed either from squidguard 1.4 to 1.5 or on debian jessie. Squidguard now loads in vyos 1.2.0. This is reported in I believe T92, and def T130. 