### PR TITLE
Add command webproxy proxy-bypass-source

### DIFF
--- a/templates-cfg/service/webproxy/proxy-bypass-source/node.def
+++ b/templates-cfg/service/webproxy/proxy-bypass-source/node.def
@@ -1,0 +1,15 @@
+multi:
+
+type: txt
+
+help: Address/network to bypass the transparent proxy based on source address
+
+syntax:expression: exec "/opt/vyatta/sbin/vyatta-validate-type.pl iptables4_addr $VAR(@)"
+
+create: sudo iptables -t nat -I WEBPROXY 1 -p tcp --dport 80 -s '$VAR(@)' -m comment --comment 'proxy-bypass' -j RETURN
+
+delete: sudo iptables -t nat -D WEBPROXY -p tcp --dport 80 -s '$VAR(@)' -m comment --comment 'proxy-bypass' -j RETURN
+
+val_help: ipv4 ; IPv4 source address to bypass
+val_help: ipv4net ; IPv4 source network to bypass
+


### PR DESCRIPTION
Add command `webproxy proxy-bypass-source` to bypass proxy based on source IP address.

This is useful for disabling the (e.g. transparent) proxy only for specific devices. (I am using it to make Netflix work again by disabling the IP address of my Fire TV where Netflix runs on.)

(If you are able to read German, I wrote a : [blog post](https://nerdblog.steinkopf.net/2016/09/vyos-webproxy-bypass-basierend-auf-quell-ip/) about this. Now I would like to integrate this into vyos.)