### PR TITLE
fix squid log path in node.def

### DIFF
--- a/templates-op/monitor/webproxy/access-log/node.def
+++ b/templates-op/monitor/webproxy/access-log/node.def
@@ -1,2 +1,2 @@
 help: Monitor the last lines of the squid access log
-run: sudo tail --follow=name /var/log/squid3/access.log
+run: sudo tail --follow=name /var/log/squid/access.log


### PR DESCRIPTION
command "monitor webproxy access-log" gives error:
tail: cannot open '/var/log/squid3/access.log' for reading: no such file or directory

fixed pathname