### PR TITLE
fix squid log path in node.def

### DIFF
--- a/templates-op/monitor/webproxy/cache-log/node.def
+++ b/templates-op/monitor/webproxy/cache-log/node.def
@@ -1,2 +1,2 @@
 help: Monitor the last lines of the squid cache log
-run: sudo tail --follow=name /var/log/squid3/cache.log
+run: sudo tail --follow=name /var/log/squid/cache.log


### PR DESCRIPTION
command "monitor webproxy cache-log" gives error:
tail: cannot open '/var/log/squid3/cache.log' for reading: No such file or directory

fixed pathname